### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/Helpful_projects/Quick_start/README.md
+++ b/Helpful_projects/Quick_start/README.md
@@ -1,4 +1,4 @@
-####For Ubuntu 12.04 Users.
+#### For Ubuntu 12.04 Users.
 
 Download these files and run:
 
@@ -14,7 +14,7 @@ here.
 
 (Still needs work buts gets most of the big stuff.)
 
-####New Stuff:
+#### New Stuff:
 
 The files:
 
@@ -27,7 +27,7 @@ directory.  You will need to edit them to set your default path.
 You still need to use Stop IPython Notebook.sh when you are done to close all of
 the IPython processes.
 
-####Update: 
+#### Update: 
 
 Quick_install.sh is now out of date with the release of IPython 1.1 but a lot of
 the packages it installs still need to be installed.  My current procedure uses 
@@ -94,20 +94,20 @@ However I guess I could have used these instead:
 
 I'm also not sure if these would have installed the IPython Notebook.
 
-####LaTex File Conversion
+#### LaTex File Conversion
 
 In order to use nbconvert to create a LaTex file or a LaTex pdf you will also need to install the following:
 
     sudo apt-get install texlive.base
     sudo apt-get install texlive-latex-extra
 
-####Trouble Shooting
+#### Trouble Shooting
 
 The easiest way to find out why something doesn't work is to run the command from the terminal 
 and read the error messages to determine what packages are missing and/or what commands have 
 errors in them.
 
-###Final Note on Executing Scripts and Programs
+### Final Note on Executing Scripts and Programs
 
 In order to be able to run a script by clicking on it you will need to enable nautilus within dconfg-editor.
 The followinf instructions were written by Basharat Sial [here](http://askubuntu.com/questions/138908/how-to-execute-a-script-just-by-double-clicking-like-exe-files-in-windows).

--- a/Helpful_projects/README.md
+++ b/Helpful_projects/README.md
@@ -3,13 +3,13 @@ Useful IPython Notebooks and Related Code
 
 This is a list of projects/links I have found useful for quick referance examples.
 
-####Referances and collections
+#### Referances and collections
 * [IPython Official Notebook Collection](https://github.com/ipython/ipython/tree/master/examples/notebooks#a-collection-of-notebooks-for-using-ipython-effectively)
 * [A gallery of interesting IPython Notebooks](https://github.com/ipython/ipython/wiki/A-gallery-of-interesting-IPython-Notebooks)
 * [Markdown Reference](http://daringfireball.net/projects/markdown/)
 
-####Tutorials
-#####Basic Programming Education
+#### Tutorials
+##### Basic Programming Education
 * [Python Programming for the Humanities](https://github.com/fbkarsdorp/python-course#python-programming-for-the-humanities)
 * [Lectures introducing scientific computing with Python using IPython](https://github.com/jrjohansson/scientific-python-lectures#lectures-on-scientific-computing-with-python)
 * [IPython - beyond plain Python](http://nbviewer.ipython.org/urls/raw.github.com/ipython/ipython-in-depth/master/notebooks/IPython%20-%20beyond%20plain%20Python.ipynb)
@@ -19,18 +19,18 @@ This is a list of projects/links I have found useful for quick referance example
 * [A Crash Course in Python for Scientists](http://nbviewer.ipython.org/5920182)
     * [...for IPython3](http://nbviewer.ipython.org/5924718)
 
-#####Machine Learning
+##### Machine Learning
 * [Machine learning with scikit-learn](http://scikit-learn.org/stable/)
 * [Scikit-learn tutorial](https://github.com/amueller/tutorial_ml_gkbionics#tutorial_ml_gkbionics)
 * [Scikit-image and other scikits](http://scikits.scipy.org/scikits)
 * [SimpleCV computer vision](http://www.reddit.com/r/IPython/comments/1e4ojm/simplecv_computer_vision_tutorial_using_ipython/)
 
-#####Web Scraping and Data Mining
+##### Web Scraping and Data Mining
 * [Mining the Social Web, (2nd Edition)](https://github.com/ptwobrussell/Mining-the-Social-Web-2nd-Edition#mining-the-social-web-2nd-edition)
 * [Webscraping example](http://nbviewer.ipython.org/4743272)
 * [Learn Pandas](https://bitbucket.org/hrojas/learn-pandas)
 
-#####Data Presentation
+##### Data Presentation
 Audible
 * [Csound Tutorial](http://nbviewer.ipython.org/5535792)
 * [The sound Of Hydrogen](http://nbviewer.ipython.org/urls/raw.github.com/Carreau/posts/master/07-the-sound-of-hydrogen.ipynb)
@@ -41,7 +41,7 @@ Visual
 * [Learn Pandas (repeated from above)](https://bitbucket.org/hrojas/learn-pandas)
 * [Matplotlib Gallery](http://matplotlib.org/gallery.html)
 
-#####More Advanced Programming Education
+##### More Advanced Programming Education
 * [Treating notebooks as a library](http://nbviewer.ipython.org/5491090/analysis.ipynb)
 * [IPython extension index](https://github.com/ipython/ipython/wiki/Extensions-Index)
 * [Numba: 1400x Speedup of Python code in a single line](http://jakevdp.github.io/blog/2013/06/15/numba-vs-cython-take-2/)

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ The final goal is to have versions that include .png, .html, .svg, and .pdf form
 SVG Images
 ========================
 
-###Basic Commands
+### Basic Commands
 
 ![Basic help](http://damontallen.github.io/IPython-quick-ref-sheets/svg/Basic_Help.svg)
 
-###Magic Commands
+### Magic Commands
 ![Magic help](http://damontallen.github.io/IPython-quick-ref-sheets/svg/Magic_only.svg)
 
 The IPython Notebook used to develop the SVG images is [here](http://nbviewer.ipython.org/urls/raw.github.com/damontallen/IPython-quick-ref-sheets/master/SVG_Table_Builder.ipynb).  It contains a custom magic command to grab the text of the %quickref magic command.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
